### PR TITLE
added support for multiple output nodes/layers in Tensorboard callback

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -520,9 +520,12 @@ class TensorBoard(Callback):
 
                         tf.image_summary(weight.name, w_img)
 
-                if hasattr(layer, 'output'):
-                    tf.histogram_summary('{}_out'.format(layer.name),
-                                         layer.output)
+                if hasattr(layer, 'get_output_at'):
+                    # theres potentially more than one output node, collect summaries for all of them
+                    for i in range(len(layer.inbound_nodes)):
+                        tf.histogram_summary('{}_out_{}'.format(layer.name, i),
+                                             layer.get_output_at(i))
+
         if parse_version(tf.__version__) >= parse_version('0.12.0'):
             self.merged = tf.summary.merge_all()
         else:


### PR DESCRIPTION
- when recording the activations via TB-callback, it will raise an
  Exception if it encounters a node with multiple outputs and tries to
  collect its statistics
- instead, now the stats are recorded for each ouput node seperately
- in addition, TB-callback skipped over layers that had no 'ouput'
  attribute but a 'get_output_at' method. fixed that as well